### PR TITLE
visually hiding nfts when we encounter problems

### DIFF
--- a/src/containers/ProfilePage/EditDrawer/EditBadgesForm.tsx
+++ b/src/containers/ProfilePage/EditDrawer/EditBadgesForm.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Button, Icon, Input, Text, Tooltip } from '@chakra-ui/react';
-import { MdAdd, MdRemove, MdDragIndicator } from 'react-icons/md';
+import { MdAdd, MdRemove, MdDragIndicator, MdWarning } from 'react-icons/md';
 import { Droppable, Draggable, DraggingStyle } from 'react-beautiful-dnd';
 import IconButton from '../../../components/IconButton';
 import useAppDispatch from '../../../hooks/useAppDispatch';
@@ -12,6 +12,7 @@ import {
   selectCurrency,
   selectFungibleToken,
   selectGroups,
+  selectHiddenBadges,
   selectNonFungibleToken,
   selectStatistic,
   selectStoreAssets,
@@ -146,6 +147,7 @@ function Item({
 }) {
   const intl = useIntl();
   const dispatch = useAppDispatch();
+  const hiddenBadges = useAppSelector(selectHiddenBadges);
   const { id, type, index } = item;
 
   let label: ReactNode;
@@ -193,6 +195,18 @@ function Item({
             </Box>
             {label}
             <Box flexGrow={1}></Box>
+            {hiddenBadges[id] && (
+              <Tooltip
+                label={intl.formatMessage({
+                  id: 'visually-hidden',
+                  defaultMessage: 'We had problems loading this badge. It is being visually hidden from the screen.',
+                })}
+              >
+                <span>
+                  <Icon as={MdWarning} w={5} h={5} color="yellow.300" />
+                </span>
+              </Tooltip>
+            )}
             <IconButton
               aria-label={intl.formatMessage({ id: 'aria-remove-item', defaultMessage: 'Remove Item' })}
               tooltip={intl.formatMessage({ id: 'remove-item', defaultMessage: 'Remove Item' })}

--- a/src/containers/ProfilePage/Profile/Groups.tsx
+++ b/src/containers/ProfilePage/Profile/Groups.tsx
@@ -6,7 +6,7 @@ import Paper from '../../../components/Paper';
 import useAppSelector from '../../../hooks/useAppSelector';
 import FungibleTokenComponent from './FungibleToken';
 import NonFungibleTokenComponent from './NonFungibleToken';
-import { selectGroups, selectLoading } from './../slice';
+import { selectGroups, selectHiddenBadges, selectLoading } from './../slice';
 import Statistic from './Statistic';
 import Currency from './Currency';
 import Divider from './Divider';
@@ -25,6 +25,8 @@ function Groups() {
 }
 
 function Group({ text, items }: { text: string; items: DisplayItem[] }) {
+  const hiddenBadges = useAppSelector(selectHiddenBadges);
+
   return (
     <Box mt={20}>
       <GroupTitle text={text} />
@@ -35,17 +37,19 @@ function Group({ text, items }: { text: string; items: DisplayItem[] }) {
           justifyContent="space-between"
           gap={20}
         >
-          {items.map(({ type, index, id }) => {
-            return (
-              <GridItem key={id}>
-                <Center>
-                  <ErrorBoundary>
-                    <GroupItem type={type} index={index} />
-                  </ErrorBoundary>
-                </Center>
-              </GridItem>
-            );
-          })}
+          {items
+            .filter(({ id }) => !hiddenBadges[id])
+            .map(({ type, index, id }) => {
+              return (
+                <GridItem key={id}>
+                  <Center>
+                    <ErrorBoundary>
+                      <GroupItem type={type} index={index} id={id} />
+                    </ErrorBoundary>
+                  </Center>
+                </GridItem>
+              );
+            })}
         </Grid>
       )}
     </Box>
@@ -62,7 +66,7 @@ function GroupTitle({ text }: { text: string }) {
   );
 }
 
-function GroupItem({ type, index }: { type: BadgeTypes | undefined; index: number }) {
+function GroupItem({ type, index, id }: { type: BadgeTypes | undefined; index: number; id: string }) {
   const loading = useAppSelector(selectLoading);
 
   if (loading) {
@@ -77,7 +81,7 @@ function GroupItem({ type, index }: { type: BadgeTypes | undefined; index: numbe
 
   switch (type) {
     case BadgeTypes.NonFungibleToken:
-      return <NonFungibleTokenComponent index={index} />;
+      return <NonFungibleTokenComponent index={index} id={id} />;
     case BadgeTypes.FungibleToken:
       return <FungibleTokenComponent index={index} />;
     case BadgeTypes.Statistics:

--- a/src/containers/ProfilePage/Profile/NonFungibleToken.tsx
+++ b/src/containers/ProfilePage/Profile/NonFungibleToken.tsx
@@ -1,33 +1,44 @@
-import { Flex, Image, Text, Heading, Box, Center, SimpleGrid, GridItem } from '@chakra-ui/react';
+import { Flex, Image, Text, Heading, Box, SimpleGrid, GridItem, Spinner, Center } from '@chakra-ui/react';
 import { BADGE_HEIGHT, BADGE_WIDTH } from '../../../common/constants';
 import Badge from './Badge';
 import useOpenSeaUrl from '../../../hooks/useOpenSeaUrl';
 import useAppSelector from '../../../hooks/useAppSelector';
-import { selectColors, selectNonFungibleToken } from './../slice';
+import { hideBadge, selectColors, selectNonFungibleToken } from './../slice';
 import Link from '../../../components/Link';
 import { Contract, NonFungibleMetadata } from '../../../common/types';
-import Paper from './Paper';
 import useHexToRgb from '../../../hooks/useHexToRgb';
 import { useIntl } from 'react-intl';
 import useTrimmedString from '../../../hooks/useTrimmedString';
+import useAppDispatch from '../../../hooks/useAppDispatch';
+import { useEffect } from 'react';
 
 function NonFungibleTokenComponent({
+  id,
   index,
   usePaper = true,
   useHeader = true,
 }: {
+  id: string;
   index: number;
   usePaper?: boolean;
   useHeader?: boolean;
 }) {
+  const dispatch = useAppDispatch();
   const { metadata, contract, token_id, balance } = useAppSelector((state) => selectNonFungibleToken(state, index));
 
-  // user does not own this nft. we should not display it and imply they own it
-  // we do not check for null/undefined explicitely here because they are considered to usually be transient errors that have happened internally.
-  // in those scenarios we still want to show as much of the users profile as possible
-  // and so we will erh on the side of believing the user has a positive balance when the balance is null/undefined
-  if (balance === '0') {
-    return <Paper width={BADGE_WIDTH} height={useHeader ? BADGE_HEIGHT : BADGE_WIDTH} />;
+  // Three scenarios to account for here:
+  //  1. Nil metadata. Failing to fetch metadata can be transient or a miss configuration.
+  //  2. Nil balance. Failing to fetch the balance can be transient or a miss configuration.
+  //  3. Zero balance. The user does not own this nft.
+  // We will opt to visually hide the badge from the screen in all three of these scenarios
+  useEffect(() => {
+    if (!metadata || !balance || balance === '0') {
+      dispatch(hideBadge(id));
+    }
+  }, [id, metadata, balance, dispatch]);
+
+  if (!metadata || !balance || balance === '0') {
+    return <></>;
   }
 
   return (
@@ -35,7 +46,7 @@ function NonFungibleTokenComponent({
       width={BADGE_WIDTH}
       height={useHeader ? BADGE_HEIGHT : BADGE_WIDTH}
       usePaper={usePaper}
-      Display={<NonFungibleDisplay metadata={metadata} useHeader={useHeader} />}
+      Display={<NonFungibleDisplay id={id} metadata={metadata} useHeader={useHeader} />}
       DialogHeader={<NonFungibleHeader metadata={metadata} />}
       DialogBody={<NonFungibleDialog token_id={token_id} metadata={metadata} contract={contract} balance={balance} />}
     />
@@ -43,22 +54,19 @@ function NonFungibleTokenComponent({
 }
 
 function NonFungibleDisplay({
+  id,
   metadata,
   useHeader,
 }: {
-  metadata: NonFungibleMetadata | undefined;
+  id: string;
+  metadata: NonFungibleMetadata;
   useHeader: boolean;
 }) {
-  // we more than likely failed to fetch the metadata. we should display gracefully here and simply return an empty display
-  if (!metadata) {
-    return <></>;
-  }
-
   const { name, image } = metadata;
 
   return (
     <Box maxHeight="100%" maxWidth="100%">
-      <ImageWrapper image={image} alt={name} fallbackText={name} />
+      <ImageWrapper image={image} id={id} />
       {useHeader && (
         <Heading size="sm" my={2} maxWidth="100%" noOfLines={1} mx={2} textColor="profile.secondaryText">
           {name}
@@ -100,12 +108,12 @@ function NonFungibleDialog({
     return <></>;
   }
 
-  const { name, image, description, attributes } = metadata;
+  const { image, description, attributes } = metadata;
 
   return (
     <Box>
       <Flex justifyContent="center">
-        <ImageWrapper image={image} alt={name} fallbackText={name} />
+        <ImageWrapper image={image} />
       </Flex>
       <Flex alignItems="center" mt={3}>
         <Heading as="h5" size="sm" textColor="profile.secondaryText">
@@ -188,16 +196,26 @@ function NonFungibleDialog({
   );
 }
 
-function ImageWrapper({ image, alt, fallbackText }: { image: string; alt: string; fallbackText: string }) {
+// If we fail to load the image, we call hideBadge to visually hide the badge from display
+// ImageWrapper is loaded by both the display and dialog component.
+// We only want to call hide badge once per image so we will call it for the display load and not the dialog laod
+// Hidden badges are respected in the group component
+function ImageWrapper({ image, id }: { image: string; id?: string }) {
+  const dispatch = useAppDispatch();
   return (
     <Flex height={BADGE_WIDTH} width={BADGE_WIDTH}>
       <Image
-        alt={alt}
+        alt=""
         fallback={
           <Center width="100%">
-            <Heading size="md">{fallbackText}</Heading>
+            <Spinner />
           </Center>
         }
+        onError={() => {
+          if (id) {
+            dispatch(hideBadge(id));
+          }
+        }}
         src={image}
         margin="auto"
         maxWidth="100%"

--- a/src/containers/ProfilePage/Profile/ProfilePicture.tsx
+++ b/src/containers/ProfilePage/Profile/ProfilePicture.tsx
@@ -36,7 +36,7 @@ function Picture() {
     );
   }
 
-  return <NonFungibleTokenComponent index={item.index} useHeader={false} usePaper={false} />;
+  return <NonFungibleTokenComponent id={item.id} index={item.index} useHeader={false} usePaper={false} />;
 }
 
 function Info() {

--- a/src/containers/ProfilePage/slice.ts
+++ b/src/containers/ProfilePage/slice.ts
@@ -23,6 +23,7 @@ export interface State {
   saveProfileState: AsyncStates;
   showEditBar: boolean;
   profile: StateProfile;
+  hiddenBadges: { [x: string]: boolean };
 }
 
 // some pre-amble about the relationship between display_config and interactions/non_fungible_tokens/fungible_tokens/statistics:
@@ -111,6 +112,7 @@ const initialState: State = {
     statistics: [],
     currencies: [],
   },
+  hiddenBadges: {}, // these badge ids will be hidden during rendering
 };
 
 export const loadProfile = createAsyncThunk<Profile | undefined, { address: string }, { state: RootState }>(
@@ -238,6 +240,9 @@ export const slice = createSlice({
       }
       achievements.splice(action.payload, 1);
       state.profile[achievementBeingDeleted.type].splice(achievementBeingDeleted.index, 1);
+    },
+    hideBadge: (state, action: PayloadAction<string>) => {
+      state.hiddenBadges[action.payload] = true;
     },
   },
   extraReducers: (builder) => {
@@ -525,6 +530,8 @@ export const selectBadgeCount = (state: RootState) =>
 
 export const selectInteractions = (state: RootState) => state.profilePage.profile.interactions;
 
+export const selectHiddenBadges = (state: RootState) => state.profilePage.hiddenBadges;
+
 export default slice.reducer;
 
 export const {
@@ -545,4 +552,5 @@ export const {
   removeItem,
   updateAchievementText,
   removeAchievement,
+  hideBadge,
 } = slice.actions;


### PR DESCRIPTION
- Leveraging the onError callback of the image component to visuallly hide nft badges when we fail to load the image
- Using this same new mechanism to hide nft badges when we have nil metadata/balance or a zero balance
- Showing a warning icon in the edit badge drawer indicatin the nft had problems and is being visually hidden.
