### PR TITLE
accounting for slice of profiles in spotlight response

### DIFF
--- a/src/containers/TrendingPage/index.tsx
+++ b/src/containers/TrendingPage/index.tsx
@@ -55,12 +55,12 @@ function TrendingPage() {
       <Heading as="h2" fontSize="2xl" textAlign="center" mb={5}>
         {intl.formatMessage({ id: 'spotlight-profile-caption', defaultMessage: 'Spotlight Profile' })}
       </Heading>
-      {loading || !spotlightProfile ? (
+      {loading || !spotlightProfile.length ? (
         <Box mx="8px" my="18px">
           <Skeleton width={maxWidth} height="64px" borderRadius="8px" />
         </Box>
       ) : (
-        <Row profile={spotlightProfile} />
+        <Row profile={spotlightProfile[0]} />
       )}
       <Box my="150px" />
       <Heading as="h2" fontSize="2xl" textAlign="center" mb={5}>

--- a/src/containers/TrendingPage/slice.ts
+++ b/src/containers/TrendingPage/slice.ts
@@ -7,21 +7,21 @@ import { RootState } from '../../store';
 export interface State {
   getProfilesState: AsyncStates;
   trendingProfiles: Profile[];
-  spotlightProfile: Profile | undefined;
+  spotlightProfile: Profile[];
 }
 
 const initialState: State = {
   getProfilesState: AsyncStates.PENDING,
   trendingProfiles: [],
-  spotlightProfile: undefined,
+  spotlightProfile: [],
 };
 
-export const getProfiles = createAsyncThunk<[Profile[], Profile], undefined, { state: RootState }>(
+export const getProfiles = createAsyncThunk<[Profile[], Profile[]], undefined, { state: RootState }>(
   'home/getProfiles',
   async () => {
     const [trending, spotlight] = await Promise.all([
       FetchProfilesAPI<Profile[]>('/profiles/top'),
-      FetchProfilesAPI<Profile>('/profiles/spotlight'),
+      FetchProfilesAPI<Profile[]>('/profiles/spotlight'),
     ]);
 
     if (trending.error || !trending.data) {
@@ -44,7 +44,7 @@ export const slice = createSlice({
     builder.addCase(getProfiles.pending, (state) => {
       state.getProfilesState = AsyncStates.PENDING;
       state.trendingProfiles = [];
-      state.spotlightProfile = undefined;
+      state.spotlightProfile = [];
     });
     builder.addCase(getProfiles.fulfilled, (state, action) => {
       const [trendingProfiles, spotlightProfile] = action.payload;


### PR DESCRIPTION
Just taking the first spotlight profile for now to keep existing behavior. Will refactor the Trending page later to leverage multiple spotlight profiles